### PR TITLE
Fixing syntax errors in makefile.unix

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -144,7 +144,7 @@ OBJS= \
     obj/kernel_worker.o \
     obj/ecies.o \
     obj/cryptogram.o \
-    obj/scrypt.o
+    obj/scrypt.o \
     obj/scrypt-sse2.o \
     obj/ipcollector.o
 


### PR DESCRIPTION
 that resulted in "makefile.unix 148: *** missing separator.  Stop." when compiling